### PR TITLE
Remove Waseda and Tokai from team list

### DIFF
--- a/teams.rb
+++ b/teams.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 module Teams
-  # NOTE: The following 5 teams operate own games manually, so we don't need to be notified.
-  # 明治大学, 慶應義塾大学, 法政大学, 駒澤大学, 東海大学
+  # NOTE: The following teams operate own games manually, so we don't need to be notified.
+  # 早稲田, 明治大学, 慶應義塾大学, 法政大学, 駒澤大学, 東海大学
   LIST = %w[
-    早稲田大学
     神奈川大学
     青山学院大学
     筑波大学
     大東文化大学
     日本大学
-    東海大学
     白鴎大学
     専修大学
     日本体育大学

--- a/teams.rb
+++ b/teams.rb
@@ -2,7 +2,7 @@
 
 module Teams
   # NOTE: The following teams operate own games manually, so we don't need to be notified.
-  # 早稲田, 明治大学, 慶應義塾大学, 法政大学, 駒澤大学, 東海大学
+  # 早稲田大学, 明治大学, 慶應義塾大学, 法政大学, 駒澤大学, 東海大学
   LIST = %w[
     神奈川大学
     青山学院大学


### PR DESCRIPTION
# Description

- 早稲田 → ロストしたけどもう一回やりたいらしいのでこちらも紐付け要らず
- 東海 → 運営してくれてるので紐付け要らず